### PR TITLE
Add basic positive lookahead support

### DIFF
--- a/lib/randexp.js
+++ b/lib/randexp.js
@@ -185,8 +185,12 @@ function gen(token, groups) {
 
     case types.ROOT:
     case types.GROUP:
-      // Ignore lookaheads for now.
-      if (token.followedBy || token.notFollowedBy) { return ''; }
+      if (token.followedBy) {
+        this.following = true;
+      }
+      else if (token.notFollowedBy) {
+        return '';
+      }
 
       // Insert placeholder until group string is generated.
       if (token.remember && token.groupNumber === undefined) {
@@ -214,7 +218,7 @@ function gen(token, groups) {
 
     case types.SET:
       var expandedSet = expand.call(this, token);
-      if (!expandedSet.length) { return ''; }
+      if (!expandedSet.length || this.following) { return ''; }
       return String.fromCharCode(randSelect.call(this, expandedSet));
 
 

--- a/test/main-test.js
+++ b/test/main-test.js
@@ -72,8 +72,27 @@ describe('Call without a string or regular expression', function() {
 });
 
 describe('Followed by groups', function() {
-  it('Generate nothing, for now', function() {
-    assert.equal(randexp(/hi(?= no one)/), 'hi');
-    assert.equal(randexp(/hi(?! no one)/), 'hi');
+  it('Respects positive lookaheads', function() {
+    var pattern = '^(?=a).$';
+    var r = new RandExp(pattern);
+    var example = r.gen();
+    assert.equal(example.length, 1);
+    assert.equal(example, 'a')
+
+    var match = example.match(pattern);
+
+    assert.equal(match.length, 1);
+    assert.equal(match[0], 'a');
+  });
+
+  it('Generate positive lookahead pattern', function() {
+    var positivePattern = /hi(?= no one)/;
+    var negativePattern = /hi(?! no one)/;
+    assert.equal(randexp(positivePattern), 'hi no one');
+    assert.equal(randexp(negativePattern), 'hi');
+    assert.equal(randexp(positivePattern).match(positivePattern)[0], 'hi');
+    assert.equal(randexp(positivePattern).match(negativePattern), null);
+    assert.equal(randexp(negativePattern).match(negativePattern)[0], 'hi');
+    assert.equal(randexp(negativePattern).match(positivePattern), null);
   });
 });


### PR DESCRIPTION
Addresses basic implementation for #18 .

Basic cases not previously supported that now pass:
```Javascript
const justA = randexp('^(?=a).$');            // justA === 'a'

const positivePattern = '^hi(?= no one)';
const lookAhead = randexp(positivePattern);   // lookAhead === 'hi no one'
lookAhead.match(positivePattern);             // -->> [ 'hi', index: 0, input: 'hi no one' ]

const negativePattern = '^hi(?! no one)';
const noLookAhead = randexp(negativePattern); // noLookAhead === 'hi'
noLookAhead.match(negativePattern);           // -->> [ 'hi', index: 0, input: 'hi' ]
lookAhead.match(negativePattern);             // -->> null
```