### PR TITLE
ERROR in typescript snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ npm test
 RandExp includes TypeScript definitions.
 
 ```typescript
-import * as RandExp from "randexp";
+import RandExp from "randexp";
 const randexp = new RandExp(/[a-z]{6}/);
 randexp.gen();
 ```


### PR DESCRIPTION
You don't have to use `* as` when its already exporting `RandExp`