### PR TITLE
Added sideEffects: false to allow tree shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,5 +47,6 @@
     "node": ">=8"
   },
   "license": "MIT",
-  "types": "./types"
+  "types": "./types",
+  "sideEffects": false
 }


### PR DESCRIPTION
As far as I see there is no side effects in this package.

To allow tree shaking when CommonJS then we can add `"sideEffects": false`.

So tools like Esbuild, Rollup and minifiers can strip that code from bundles.